### PR TITLE
rename lzo2 to lzo package (upstream changed)

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -23,7 +23,7 @@ set -e -u -o pipefail
 # Packages needed by pacman (see get-pacman-dependencies.sh)
 PACMAN_PACKAGES=(
   acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive
-  libassuan libgpg-error libssh2 lzo2 openssl pacman pacman-mirrorlist xz zlib
+  libassuan libgpg-error libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
   krb5 e2fsprogs gcc-libs keyutils
 )
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)


### PR DESCRIPTION
Arch package `lzo2` was replaced by `lzo`. I've updated arch-bootstrap.sh to match this change
