### PR TITLE
Add libidn to $PACMAN_PACKAGES

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -23,7 +23,7 @@ set -e -u -o pipefail
 # Packages needed by pacman (see get-pacman-dependencies.sh)
 PACMAN_PACKAGES=(
   acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive
-  libassuan libgpg-error libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
+  libassuan libgpg-error libidn libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
   krb5 e2fsprogs gcc-libs keyutils
 )
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)


### PR DESCRIPTION
This fix is required for script to correctly work (as of 2014-12-06) Pacman requires this library to be able to start and bootstrap rest of packages correctly
